### PR TITLE
Onboard app2: add all artifacts, config, and update applications.yaml for app2 onboarding

### DIFF
--- a/applications.yaml
+++ b/applications.yaml
@@ -1,4 +1,8 @@
+# filepath: /Users/vaibhav.verma/Desktop/MCP-test/applications.yaml
 applications:
   - name: "existing-app-1"
     owner: "team-alpha"
     repository: "https://github.com/example/existing-app-1"
+  - name: "app2"
+    owner: "team-beta"
+    repository: "https://github.com/example/app2"

--- a/apps/app2/config.yaml
+++ b/apps/app2/config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "app2-config"
+data:
+  db_url: "jdbc:postgresql://db-host:5432/app2"
+  redis_host: "redis-service:6379"
+  logging_level: "INFO"
+  external_api: "https://api.example.com/v1"

--- a/apps/app2/deployment.yaml
+++ b/apps/app2/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "app2-deployment"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: "app2"
+  template:
+    metadata:
+      labels:
+        app: "app2"
+    spec:
+      containers:
+      - name: "app2"
+        image: "example/app2:latest"
+        ports:
+        - containerPort: 8081
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
+        envFrom:
+        - configMapRef:
+            name: "app2-config"
+        - secretRef:
+            name: "app2-secret"
+        livenessProbe:
+          httpGet:
+            path: "/app2/actuator/health"
+            port: 8081
+        readinessProbe:
+          httpGet:
+            path: "/app2/actuator/health"
+            port: 8081

--- a/apps/app2/ingress.yaml
+++ b/apps/app2/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "app2-ingress"
+spec:
+  tls:
+    - hosts:
+        - "app2.example.com"
+      secretName: "app2-tls"
+  rules:
+    - host: "app2.example.com"
+      http:
+        paths:
+          - path: "/app2"
+            pathType: Prefix
+            backend:
+              service:
+                name: "app2-service"
+                port:
+                  number: 80

--- a/apps/app2/networkpolicy.yaml
+++ b/apps/app2/networkpolicy.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "app2-network-policy"
+spec:
+  podSelector:
+    matchLabels:
+      app: "app2"
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: "namespace-a"
+    - namespaceSelector:
+        matchLabels:
+          name: "namespace-b"
+    ports:
+    - port: 8081
+    - port: 5432
+    - port: 6379
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          app: "database"
+    - podSelector:
+        matchLabels:
+          app: "redis"
+    - podSelector:
+        matchLabels:
+          app: "external-api"
+    ports:
+    - port: 8081
+    - port: 5432
+    - port: 6379

--- a/apps/app2/readme.md
+++ b/apps/app2/readme.md
@@ -1,0 +1,25 @@
+# app2
+
+This is the documentation for the app2 application.
+
+## Owner
+
+team-beta
+
+## Repository
+
+https://github.com/example/app2
+
+## Business Owner
+
+Jane Smith
+
+## Technical Owner
+
+John Doe
+
+## Monitoring
+
+- Metrics Path: /app2/actuator/prometheus
+- Alert Contacts: team-beta@example.com
+- Dashboards: app2-overview, app2-detailed

--- a/apps/app2/secret.yaml
+++ b/apps/app2/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "app2-secret"
+type: Opaque
+data:
+  db_username: "YXBwMl91c2Vy"  # base64 for 'app2_user'
+  db_password: "c2VjcmV0MTIz"  # base64 for 'secret123'
+  api_key: "YWJjZDEyMzQ="      # base64 for 'abcd1234'

--- a/apps/app2/service.yaml
+++ b/apps/app2/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "app2-service"
+spec:
+  type: ClusterIP
+  selector:
+    app: "app2"
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8081

--- a/apps/app2/servicemonitor.yaml
+++ b/apps/app2/servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: "app2-servicemonitor"
+spec:
+  selector:
+    matchLabels:
+      app: "app2"
+  endpoints:
+  - port: 8081
+    path: "/app2/actuator/prometheus"
+  namespaceSelector:
+    matchNames:
+      - default


### PR DESCRIPTION
This PR onboards a new application, app2, by adding all necessary Kubernetes artifacts, configuration, and updating applications.yaml. Artifacts include deployment, service, ingress, configmap, secret, network policy, and monitoring resources for app2.